### PR TITLE
[Performance] Remove unused GC

### DIFF
--- a/net.jeeeyul.eclipse.themes/src/net/jeeeyul/eclipse/themes/rendering/HackedCTabRendering.java
+++ b/net.jeeeyul.eclipse.themes/src/net/jeeeyul/eclipse/themes/rendering/HackedCTabRendering.java
@@ -333,8 +333,6 @@ public class HackedCTabRendering extends CTabFolderRenderer {
 	}
 
 	protected Rectangle computeTrim(int part, int state, int x, int y, int width, int height) {
-		GC gc = new GC(parent);
-		gc.dispose();
 		int borderTop = TOP_KEYLINE + OUTER_KEYLINE;
 		int borderBottom = INNER_KEYLINE + OUTER_KEYLINE;
 		int marginHeight = parent.marginHeight;


### PR DESCRIPTION
create a new GC and disposing it can be costly depending on the platform
(as a matter of fact it is quite costly on linux)
After a profiling session of the theme while resizing the IDE window I
noticed that

net.jeeeyul.eclipse.themes.rendering.HackedCTabRendering.computeTrim(int,
int, int, int, int, int)

is creating a new GC and disposing it right away never using it. 
