### PR TITLE
I implemented referencing theme colors by name in user CSS. 

### DIFF
--- a/net.jeeeyul.eclipse.themes/src/net/jeeeyul/eclipse/themes/css/ChromeCSSGenerator.xtend
+++ b/net.jeeeyul.eclipse.themes/src/net/jeeeyul/eclipse/themes/css/ChromeCSSGenerator.xtend
@@ -41,8 +41,8 @@ class ChromeCSSGenerator {
 				url('bundleclass://net.jeeeyul.eclipse.themes/net.jeeeyul.eclipse.themes.rendering.ChromeTabRendering');
 		
 			padding: «config.partStackPadding»px «config.partStackPadding + 5»px «config.partStackPadding + 7»px «config.partStackPadding + 5»px; /* top left bottom right */
-			swt-tab-outline: «config.inactiveOulineColor.toHtmlColor»;
-			swt-outer-keyline-color: «config.inactiveOulineColor.toHtmlColor»;
+			swt-tab-outline: «config.inactiveOutlineColor.toHtmlColor»;
+			swt-outer-keyline-color: «config.inactiveOutlineColor.toHtmlColor»;
 			swt-unselected-tabs-color: «config.inactivePartGradientStart.toHtmlColor» «config.inactivePartGradientEnd.toHtmlColor» «config.inactiveSelectedTabEndColor.toHtmlColor» 99% 100%;
 			swt-shadow-visible: «config.usePartShadow»;
 			
@@ -62,8 +62,8 @@ class ChromeCSSGenerator {
 		
 		.MPartStack.active {
 			swt-inner-keyline-color: #FFFFFF;
-			swt-tab-outline: «config.activeOulineColor.toHtmlColor»;
-			swt-outer-keyline-color: «config.activeOulineColor.toHtmlColor»;
+			swt-tab-outline: «config.activeOutlineColor.toHtmlColor»;
+			swt-outer-keyline-color: «config.activeOutlineColor.toHtmlColor»;
 			swt-unselected-tabs-color: «config.activePartGradientStart.toHtmlColor» «config.activePartGradientEnd.toHtmlColor» «config.activeSelectedTabEndColor.toHtmlColor» 99% 100%;
 			
 			swt-selected-tab-fill: «config.activeSelectedTabEndColor.toHtmlColor»;
@@ -76,8 +76,8 @@ class ChromeCSSGenerator {
 		
 		.MPartStack.empty {
 			swt-unselected-tabs-color: «config.emptyPartBackgroundColor.toHtmlColor» «config.emptyPartBackgroundColor.toHtmlColor» «config.emptyPartBackgroundColor.toHtmlColor» 99% 100%;
-			swt-tab-outline: «config.emptyPartOutloneColor.toHtmlColor»;
-			swt-outer-keyline-color: «config.emptyPartOutloneColor.toHtmlColor»;
+			swt-tab-outline: «config.emptyPartOutlineColor.toHtmlColor»;
+			swt-outer-keyline-color: «config.emptyPartOutlineColor.toHtmlColor»;
 		}
 		
 		.MTrimmedWindow {

--- a/net.jeeeyul.eclipse.themes/src/net/jeeeyul/eclipse/themes/preference/IChromeThemeConfig.java
+++ b/net.jeeeyul.eclipse.themes/src/net/jeeeyul/eclipse/themes/preference/IChromeThemeConfig.java
@@ -4,7 +4,7 @@ import org.eclipse.swt.graphics.FontData;
 import org.eclipse.swt.graphics.RGB;
 
 public interface IChromeThemeConfig {
-	public abstract RGB getActiveOulineColor();
+	public abstract RGB getActiveOutlineColor();
 
 	public abstract RGB getActivePartGradientEnd();
 
@@ -14,7 +14,7 @@ public interface IChromeThemeConfig {
 
 	public abstract RGB getActiveUnselectedTitleColor();
 
-	public abstract RGB getInactiveOulineColor();
+	public abstract RGB getInactiveOutlineColor();
 
 	public abstract RGB getInactivePartGradientEnd();
 
@@ -48,7 +48,7 @@ public interface IChromeThemeConfig {
 
 	public abstract RGB getPerspectiveOutlineColor();
 
-	public abstract RGB getEmptyPartOutloneColor();
+	public abstract RGB getEmptyPartOutlineColor();
 
 	public abstract RGB getEmptyPartBackgroundColor();
 


### PR DESCRIPTION
This allows one write user CSS like this while taking advantage hue shifting etc: 

.MPartStack {
    swt-unselected-tabs-color: #000 
'#InactivePartGradientStart' 
'#InactivePartGradientEnd' 
'#InactiveOutlineColor' 
'#InactiveOutlineColor' 
'#InactiveSelectedTabEndColor' 
0% 49% 55% 99% 100%; 
}

.MPartStack.active {
    swt-unselected-tabs-color: #000 
'#ActivePartGradientStart' 
'#ActivePartGradientEnd'
'#ActiveOutlineColor' 
'#ActiveOutlineColor' 
'#ActiveSelectedTabEndColor'
0% 49% 55% 99% 100%;
}
