### PR TITLE
I added CSS to comply with Pydev "StyledText" class name

### DIFF
--- a/net.jeeeyul.eclipse.themes/src/net/jeeeyul/eclipse/themes/css/ChromeCSSGenerator.xtend
+++ b/net.jeeeyul.eclipse.themes/src/net/jeeeyul/eclipse/themes/css/ChromeCSSGenerator.xtend
@@ -200,7 +200,8 @@ class ChromeCSSGenerator {
 			}
 		«ENDIF»
 		
-		.MPart.Editor StyledText{
+		.MPart.Editor StyledText,
+		.MPart.Editor StyledTextWithoutVerticalBar{
 			chrome-line-style: «config.editorLineStyle»;
 			chrome-line-color: «config.editorLineColor.toHtmlColor»;
 		}


### PR DESCRIPTION
I found that the CSS "chrome-line-style" and color not work in Pydev.
After several days trying, I found that current pydev has different class name, those the configured style ignored.

The solution is to add the pydev's Eclipse Editor class name "StyledTextWithoutVerticalBar", together with CSS definition of "StyledText"

I've described the problem here: https://github.com/x2nie/pydev#minor-bug-of-pydev---eclipse-4-css--theme
