### PR TITLE
Fix to color names not getting replaced with values in user CSS due to

### DIFF
--- a/net.jeeeyul.eclipse.themes/src/net/jeeeyul/eclipse/themes/preference/ChromeThemeConfig.java
+++ b/net.jeeeyul.eclipse.themes/src/net/jeeeyul/eclipse/themes/preference/ChromeThemeConfig.java
@@ -565,7 +565,7 @@ public class ChromeThemeConfig implements IPropertyChangeListener, IChromeThemeC
 	}
 
 	private String replace(String css) {
-		Method[] methods = getClass().getSuperclass().getDeclaredMethods();
+		Method[] methods = getClass().getDeclaredMethods();
 		for (int i = 0; i < methods.length; i++) {
 			Method method = methods[i];
 			String name = method.getName();


### PR DESCRIPTION
looking for them in the wrong class.

Signed-off-by: Timo Kinnunen timo.kinnunen@gmail.com
